### PR TITLE
SUI-28: Menu UI suppress style warnings via styable st.css not .css

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -27,12 +27,11 @@ import {
   MenuPopoverProps as ReachMenuPopoverProps,
   MenuLinkProps as ReachMenuLinkProps
 } from "@reach/menu-button";
-import "./styles.css";
 
 import Button, { ButtonProps } from "../Button/Button";
 import { st as stList, classes as list } from "./menuList.st.css";
 import { st as stItem, classes as item } from "./menuItem.st.css";
-import { st as stLink, classes as link } from "./menuLink.st.css";
+// import { st as stLink, classes as link } from "./menuLink.st.css";
 
 export type MenuProps = ReachMenuProps;
 export type MenuButtonProps = ButtonProps;

--- a/src/components/Menu/menuList.st.css
+++ b/src/components/Menu/menuList.st.css
@@ -1,4 +1,10 @@
 /* menuList.st.css CSS API */
+@st-global-custom-property --reach-menu-button;
+
+/* Suppresses the Reach warning notifying of missing styles. */
+:root {
+  --reach-menu-button: 1;
+}
 
 .root {
   white-space: nowrap;

--- a/src/components/Menu/styles.css
+++ b/src/components/Menu/styles.css
@@ -1,4 +1,0 @@
-/* Suppresses the Reach warning notifying of missing styles. */
-:root {
-  --reach-menu-button: 1;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
   It's what will get exposed to other packages when added as a dependency.
 */
 
+import ShelleyBanner from "./components_site/ShelleyBanner/ShelleyBanner";
+
 /** Default components in alphabetical order */
 
 export { default as Blockquote } from "./components/Blockquote/Blockquote";
@@ -57,8 +59,10 @@ export * from "./components/VisuallyHidden/VisuallyHidden";
 
 /** Extras - Temp */
 
-export { default as CodeSample } from "./components_site/CodeSample/CodeSample";
-export * from "./components_site/CodeSample/CodeSample";
+// @todo Move these into a seperate package designed to help building UI libs on top of Shelley.
 
-export { default as Logo } from "./components_site/Logo/Logo";
-export * from "./components_site/Logo/Logo";
+// export { default as CodeSample } from "./components_site/CodeSample/CodeSample";
+// export * from "./components_site/CodeSample/CodeSample";
+
+// export { default as Logo } from "./components_site/Logo/Logo";
+// export * from "./components_site/Logo/Logo";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@
   It's what will get exposed to other packages when added as a dependency.
 */
 
-import ShelleyBanner from "./components_site/ShelleyBanner/ShelleyBanner";
-
 /** Default components in alphabetical order */
 
 export { default as Blockquote } from "./components/Blockquote/Blockquote";

--- a/src/styles/shelley/menu.st.css
+++ b/src/styles/shelley/menu.st.css
@@ -3,6 +3,7 @@
  * 
  * ========================================================================= */
 
+
 /* = Default project vars. */
 :import {
   -st-from: "../default/project.st.css";

--- a/src/styles/shelley/menu.st.css
+++ b/src/styles/shelley/menu.st.css
@@ -3,7 +3,6 @@
  * 
  * ========================================================================= */
 
-
 /* = Default project vars. */
 :import {
   -st-from: "../default/project.st.css";


### PR DESCRIPTION
Shelley Menu is currently a wrapped instance of Reach UI MenuButton component. Reach UI in general requires a certain CSS variable be present in order to assert that styles are present (https://reach.tech/styling) for each component else it spits out a warning. Previously we had included this via a CSS file because I think we were missing this info on how to define global CSS vars within stylable in order to suppress the console warnings https://stylable.io/docs/references/css-vars#using-global-css-variables

Solution: Remove the css file which might case issues for those with css excluded on their builds and instead deliver via our stylable file as was the intention anyway. Global variables in stylable eluded me last time.

We want to avoid using css files as it might cause issues for those using only compiling st.css files as part of their webpack config. See #28 

