### PR TITLE
feat: theming tweaks to progressBar based on usage in lace.

### DIFF
--- a/cypress/component/ProgressBar.cy.tsx
+++ b/cypress/component/ProgressBar.cy.tsx
@@ -1,23 +1,39 @@
 import React from "react";
-
 import { ProgressBar } from "../../src/ProgressBar/ProgressBar";
-
 
 const testProps = {
   "aria-label": "Loading…",
   "data-id": "progressBar",
-  "aria-valuenow": "50"
 };
 const progressBar = '[data-id="progressBar"]';
-const stepIndicator = '[data-id="stepIndicator"]';
-const stepIndicatorFill = '[data-id="stepIndicatorFill"]';
+const track = '[data-id="progressBar-track"]';
+const fill = '[data-id="progressBar-fill"]';
+const label = '[data-id="progressBar-label"]';
+const valueLabel = '[data-id="progressBar-valueLabel"]';
 
 describe("ProgressBar", () => {
-  it("renders  with value and accesibility label", () => {
-    cy.mount(<ProgressBar isIndeterminate {...testProps} />);
+  it("renders with value and accesibility label", () => {
+    const value = 50;
+    cy.mount(<ProgressBar value={value} {...testProps} />);
     cy.get('[data-id="progressBar"]')
       .should("have.attr", "aria-label", testProps["aria-label"])
-      .should("have.attr", "aria-valuenow").and("to.have.string", testProps["aria-valuenow"])
+      .should("have.attr", "aria-valuenow")
+      .and("to.have.string", value);
+    cy.get(fill)
+      .should("have.attr", "style")
+      .and("include", `width: ${value}%`);
+  });
+
+  it("renders visible label", () => {
+    cy.mount(<ProgressBar label="Visible label" value={50} {...testProps} />);
+    cy.get(label).should("exist").and("have.text", "Visible label");
+  });
+
+  it("renders value label", () => {
+    cy.mount(
+      <ProgressBar valueLabel="Value label" value={50} {...testProps} />
+    );
+    cy.get(valueLabel).should("exist").and("have.text", "Value label");
   });
 
   it("renders class with custom class name", () => {
@@ -40,8 +56,11 @@ describe("ProgressBar", () => {
         <button
           onClick={() =>
             onPressSpy(
-              (ref?.current?.attributes as DataIdDOMAttribute)?.["data-id"]
-                ?.value
+              (
+                ref?.current?.attributes as {
+                  "data-id"?: { value: string };
+                }
+              )?.["data-id"]?.value
             )
           }
         >
@@ -61,7 +80,7 @@ describe("ProgressBar", () => {
 
   it("renders with custom size", () => {
     const size = "large";
-    cy.mount(<ProgressBar size={size} {...testProps} />)
+    cy.mount(<ProgressBar size={size} {...testProps} />);
   });
 
   it("renders as indeterminate", () => {
@@ -72,13 +91,10 @@ describe("ProgressBar", () => {
   });
 
   it("renders multi-step ProgressBar", () => {
-
     const multiSteProps = {
       "aria-label": "Loading…",
-      "aria-valuenow": "50",
-      "totalSteps": 5,
-      "currentStep": 3,
-      "stepProgress": 50,
+      totalSteps: 5,
+      value: 50,
       "data-id": "progressBar",
     };
 
@@ -87,20 +103,49 @@ describe("ProgressBar", () => {
     cy.get(progressBar)
       .should("have.attr", "class")
       .and("to.have.string", "ProgressBar")
-      .should("to.have.string", "multistep")
+      .should("to.have.string", "multistep");
 
-    cy.get(stepIndicator)
-      .should("have.length", multiSteProps["totalSteps"]);
+    cy.get(track).should("have.length", multiSteProps["totalSteps"]);
 
-    cy.get(stepIndicatorFill)
-      .eq(multiSteProps["currentStep"] - 1)
+    cy.get(fill)
+      .eq(2)
       .should("have.attr", "class")
       .and("to.have.string", "ProgressBar")
       .and("to.have.string", "isActive");
 
-    cy.get(stepIndicatorFill)
-      .eq(multiSteProps["currentStep"] - 1)
-      .should('have.attr', 'style').and('include', `width: ${multiSteProps["stepProgress"]}%`)
+    cy.get(fill)
+      .eq(2)
+      .should("have.attr", "style")
+      .and("include", `width: ${multiSteProps["value"]}%`);
   });
 
+  it("renders multi-step with custom scale", () => {
+    const multiSteProps = {
+      "aria-label": "Loading…",
+      totalSteps: 5,
+      value: 2.5,
+      maxValue: 5,
+      "data-id": "progressBar",
+    };
+
+    cy.mount(<ProgressBar {...multiSteProps} />);
+
+    cy.get(progressBar)
+      .should("have.attr", "class")
+      .and("to.have.string", "ProgressBar")
+      .should("to.have.string", "multistep");
+
+    cy.get(track).should("have.length", multiSteProps["totalSteps"]);
+
+    cy.get(fill)
+      .eq(2)
+      .should("have.attr", "class")
+      .and("to.have.string", "ProgressBar")
+      .and("to.have.string", "isActive");
+
+    cy.get(fill)
+      .eq(2)
+      .should("have.attr", "style")
+      .and("include", `width: 50%`);
+  });
 });

--- a/cypress/component/ProgressBar.cy.tsx
+++ b/cypress/component/ProgressBar.cy.tsx
@@ -91,21 +91,21 @@ describe("ProgressBar", () => {
   });
 
   it("renders multi-step ProgressBar", () => {
-    const multiSteProps = {
+    const multiStepProps = {
       "aria-label": "Loading…",
       totalSteps: 5,
       value: 50,
       "data-id": "progressBar",
     };
 
-    cy.mount(<ProgressBar {...multiSteProps} />);
+    cy.mount(<ProgressBar {...multiStepProps} />);
 
     cy.get(progressBar)
       .should("have.attr", "class")
       .and("to.have.string", "ProgressBar")
       .should("to.have.string", "multistep");
 
-    cy.get(track).should("have.length", multiSteProps["totalSteps"]);
+    cy.get(track).should("have.length", multiStepProps["totalSteps"]);
 
     cy.get(fill)
       .eq(2)
@@ -116,11 +116,11 @@ describe("ProgressBar", () => {
     cy.get(fill)
       .eq(2)
       .should("have.attr", "style")
-      .and("include", `width: ${multiSteProps["value"]}%`);
+      .and("include", `width: ${multiStepProps["value"]}%`);
   });
 
   it("renders multi-step with custom scale", () => {
-    const multiSteProps = {
+    const multiStepProps = {
       "aria-label": "Loading…",
       totalSteps: 5,
       value: 2.5,
@@ -128,14 +128,14 @@ describe("ProgressBar", () => {
       "data-id": "progressBar",
     };
 
-    cy.mount(<ProgressBar {...multiSteProps} />);
+    cy.mount(<ProgressBar {...multiStepProps} />);
 
     cy.get(progressBar)
       .should("have.attr", "class")
       .and("to.have.string", "ProgressBar")
       .should("to.have.string", "multistep");
 
-    cy.get(track).should("have.length", multiSteProps["totalSteps"]);
+    cy.get(track).should("have.length", multiStepProps["totalSteps"]);
 
     cy.get(fill)
       .eq(2)

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -1,19 +1,13 @@
-import {
-  CSSProperties,
-  forwardRef,
-  ReactNode,
-  Ref,
-  useEffect,
-  useState,
-} from "react";
-
+import { CSSProperties, forwardRef, Ref, useEffect, useState } from "react";
 import type { AriaProgressBarProps } from "@react-types/progress";
 import { st, classes } from "./progressBar.st.css";
 import { useProgressBar } from "@react-aria/progress";
 import type { ComponentBase, Volume } from "../typings/shared-types";
 import { Text } from "../Text";
 
-export interface ProgressBarProps extends AriaProgressBarProps, ComponentBase {
+export interface ProgressBarProps
+  extends Omit<AriaProgressBarProps, "formatOptions">,
+    ComponentBase {
   /**
    * What the ProgressCircle's diameter should be.
    * @default 'medium'
@@ -30,7 +24,9 @@ export interface ProgressBarProps extends AriaProgressBarProps, ComponentBase {
    * @default 1
    */
   totalSteps?: number;
-  children?: ReactNode;
+  /**
+   * The volume of the labels.
+   */
   vol?: Volume;
 }
 
@@ -61,6 +57,7 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledby,
     valueLabel,
+    "data-id": dataId,
     ...rest
   } = props;
 
@@ -82,7 +79,7 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
     );
     setCurrentStep(currentStep);
     setStepProgress(stepPercentage);
-  }, [value, totalSteps]);
+  }, [value, totalSteps, maxValue]);
 
   const Segment = ({
     index,
@@ -102,13 +99,17 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
     };
 
     return (
-      <div key={index} className={st(classes.track)} data-id={"stepIndicator"}>
+      <div
+        key={index}
+        className={st(classes.track)}
+        data-id={dataId ? `${dataId}-track` : undefined}
+      >
         <div
           style={fillStyle}
           className={st(classes.fill, {
             isActive: index < currentStep ? true : false,
           })}
-          data-id={"stepIndicatorFill"}
+          data-id={dataId ? `${dataId}-fill` : undefined}
         />
       </div>
     );
@@ -128,12 +129,25 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
       )}
       {...progressBarProps}
       {...rest}
+      data-id={dataId}
       ref={ref}
     >
       <Text as="div" vol={vol} className={st(classes.text)} {...labelProps}>
-        {label && <span className={st(classes.label)}>{label}</span>}
+        {label && (
+          <span
+            className={st(classes.label)}
+            data-id={dataId ? `${dataId}-label` : undefined}
+          >
+            {label}
+          </span>
+        )}
         {valueLabel && (
-          <span className={st(classes.valueLabel)}>{valueLabel}</span>
+          <span
+            className={st(classes.valueLabel)}
+            data-id={dataId ? `${dataId}-valueLabel` : undefined}
+          >
+            {valueLabel}
+          </span>
         )}
       </Text>
       <div className={st(classes.bar)}>

--- a/src/ProgressBar/ProgressBar.tsx
+++ b/src/ProgressBar/ProgressBar.tsx
@@ -81,7 +81,7 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
     setStepProgress(stepPercentage);
   }, [value, totalSteps, maxValue]);
 
-  const Segment = ({
+  const Step = ({
     index,
     currentStep,
     stepProgress,
@@ -152,7 +152,7 @@ function ProgressBar(props: ProgressBarProps, ref: Ref<HTMLDivElement>) {
       </Text>
       <div className={st(classes.bar)}>
         {Array.from({ length: totalSteps }).map((_, index) => (
-          <Segment
+          <Step
             key={index}
             index={index}
             currentStep={currentStep}

--- a/src/ProgressBar/progressBar.st.css
+++ b/src/ProgressBar/progressBar.st.css
@@ -1,120 +1,81 @@
 @namespace "ProgressBar";
 
 .root {
-
   -st-states: isIndeterminate,
     size(enum(small, medium, large)),
     overBackground,
     multistep(boolean),
     variant(enum(overBackground));
 
-  --loader-bar-small-width: 60px;
-  --loader-bar-small-height: 60px;
-  --loader-bar-small-border-size: 2px;
-
-  --loader-bar-medium-width: 150px;
-  --loader-bar-medium-height: 150px;
-  --loader-bar-medium-border-size: 3px;
-
-  --loader-bar-large-width: 300px;
-  --loader-bar-large-height: 300px;
-  --loader-bar-large-border-size: 4px;
+  --loader-bar-size-small: 2px;
+  --loader-bar-size-medium: 8px;
+  --loader-bar-size-large: 12px;
 
   --loader-bar-track-color: lightgrey;
-  --loader-bar-track-fill-color: grey;
+  --loader-bar-track-fill-color: green;
+  --loader-border-radius: calc(var(--loader-bar-size) / 2);
 
   /* Defaults to medium */
-  --loader-bar-width: var(--loader-bar-medium-width);
-  --loader-bar-height: var(--loader-bar-medium-height);
-  --loader-bar-border-size: var(--loader-bar-medium-border-size);
+  --loader-bar-size: var(--loader-bar-size-medium);
 }
 
 .root:size(small) {
-  --loader-bar-width: var(--loader-bar-small-width);
-  --loader-bar-height: var(--loader-bar-small-height);
-  --loader-bar-border-size: var(--loader-bar-small-border-size);
+  --loader-bar-size: var(--loader-bar-size-small);
 }
 
 .root:size(large) {
-  --loader-bar-width: var(--loader-bar-large-width);
-  --loader-bar-height: var(--loader-bar-large-height);
-  --loader-bar-border-size: var(--loader-bar-large-border-size);
-}
-.root {}
-
-.stepActive {}
-
-.trackWrapper {}
-
-.track {}
-
-.fill {}
-
-.label {}
-
-.stepContainer {}
-
-.stepIndicator {}
-
-.stepIndicatorFill {}
-
-.root {
-
-  width: 100%;
-  height: 8px;
-  border-radius: 4px;
-  overflow: hidden;
-  width: var(--loader-bar-width);
-  height: var(--loader-bar-height);
+  --loader-bar-size: var(--loader-bar-size-large);
 }
 
-.root:isIndeterminate .fill {
-  animation: indeterminateAnimation 2s linear infinite;
-}
-
-.step {
-  height: 100%;
-  background-color: #007a4d;
-  transition: width 0.2s ease-in-out;
-}
-
-.trackWrapper {
-  height: 10px;
-}
-
-.fill {
-  background-color: #007a4d;
-  height: 10px;
+.text {
+  display: grid;
+  margin-bottom: 8px;
 }
 
 .label {
-  color: #6a6a6a;
+  grid-row: 1;
+  justify-self: start;
 }
 
-.stepContainer {
+.valueLabel {
+  grid-row: 1;
+  justify-self: end;
+}
+
+.bar {
   display: flex;
   justify-content: space-between;
+  gap: 8px;
+  overflow: hidden;
+  border-radius: var(--loader-border-radius);
 }
 
-.stepIndicator {
+.track {
   -st-states: active;
   flex-grow: 1;
-  margin: 0 2px;
-  background-color: #e6e6e6;
+  background-color: var(--loader-bar-track-color);
+  border-radius: var(--loader-border-radius);
 }
 
-.stepIndicatorFill {
+.fill {
   -st-states: isActive;
+  height: var(--loader-bar-size);
+  border-radius: var(--loader-border-radius);
 }
 
-.stepIndicatorFill:isActive {
-  background-color: #007a4d;
+.fill:isActive {
+  background-color: var(--loader-bar-track-fill-color);
+}
+
+.root:isIndeterminate::fill {
+  animation: indeterminateAnimation 1s linear infinite;
 }
 
 @keyframes indeterminateAnimation {
   0% {
     transform: translateX(-100%);
   }
+
   100% {
     transform: translateX(200%);
   }

--- a/src/stories/UI/Blockquote.stories.mdx
+++ b/src/stories/UI/Blockquote.stories.mdx
@@ -72,7 +72,7 @@ https://www.st-andrews.ac.uk/dpl/1.15.5/patterns/long-form-quotes/index.html
 While there is no “pull quote” element, the latest iteration of the html spec encourages use of the Aside element.
 https://www.studiopress.com/how-to-use-block-quotes/#:~:text=The%20main%20purpose%20of%20a,reader%20in%20scanning%20the%20article.
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Checkbox.stories.mdx
+++ b/src/stories/UI/Checkbox.stories.mdx
@@ -271,7 +271,7 @@ Example TBC`,
 
 <ArgsTable of={Checkbox} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/CheckboxGroup.stories.mdx
+++ b/src/stories/UI/CheckboxGroup.stories.mdx
@@ -265,7 +265,7 @@ The `isReadOnly` prop makes the selection immutable. Unlike isDisabled, the Chec
 
 <ArgsTable of={CheckboxGroup} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/ComboBox.stories.mdx
+++ b/src/stories/UI/ComboBox.stories.mdx
@@ -782,7 +782,7 @@ TBC`,
 
 <ArgsTable of={ComboBox} />
 
-## Stying
+## Styling
 
 {/_ Add style info _/}
 

--- a/src/stories/UI/Dialog.stories.mdx
+++ b/src/stories/UI/Dialog.stories.mdx
@@ -327,7 +327,7 @@ Dialog can be used as part of Modal or Popup use cases. Think of them as Modal D
 
 <ArgsTable of={Dialog} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/DialogTrigger.stories.mdx
+++ b/src/stories/UI/DialogTrigger.stories.mdx
@@ -425,7 +425,7 @@ The example below uses `onOpenChange` to update a separate element with the curr
 
 <ArgsTable of={DialogTrigger} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Field.stories.mdx
+++ b/src/stories/UI/Field.stories.mdx
@@ -127,7 +127,7 @@ Setting `variant` to `false` renders without the fieldset which is suitable for 
 
 <ArgsTable of={Field} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Icon.stories.mdx
+++ b/src/stories/UI/Icon.stories.mdx
@@ -208,7 +208,7 @@ Extends `React.SVGProps`.
 
 <ArgsTable of={Icon} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/InputText.stories.mdx
+++ b/src/stories/UI/InputText.stories.mdx
@@ -80,7 +80,7 @@ https://www.st-andrews.ac.uk/dpl/1.15.5/patterns/long-form-quotes/index.html
 While there is no “pull quote” element, the latest iteration of the html spec encourages use of the Aside element.
 https://www.studiopress.com/how-to-use-block-quotes/#:~:text=The%20main%20purpose%20of%20a,reader%20in%20scanning%20the%20article.
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Label.stories.mdx
+++ b/src/stories/UI/Label.stories.mdx
@@ -121,7 +121,7 @@ _Extends `React.HTMLProps<HTMLLabelElement>`_
 
 <ArgsTable of={Label} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/MenuTrigger.stories.mdx
+++ b/src/stories/UI/MenuTrigger.stories.mdx
@@ -138,7 +138,7 @@ Additional options can be set via `popupProps`:
   </Story>
 </Canvas>
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Modal.stories.mdx
+++ b/src/stories/UI/Modal.stories.mdx
@@ -348,7 +348,7 @@ Check the table below for a full list of props.
 
 <ArgsTable of={Modal} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/ProgressBar.stories.mdx
+++ b/src/stories/UI/ProgressBar.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Source, Story } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import { Modal, ProgressBar } from "../../indexLib";
-import { StoryCenteredInline, StoryGrid } from "../StoryLayout";
+import { StoryCentered, StoryGrid } from "../StoryLayout";
 
 <Meta
   title="Status/ProgressBar"
@@ -13,6 +13,13 @@ import { StoryCenteredInline, StoryGrid } from "../StoryLayout";
       defaultValue: "over",
     },
   }}
+  decorators={[
+    (Story) => (
+      <div style={{ padding: "40px 10vw" }}>
+        <Story />
+      </div>
+    ),
+  ]}
   component={Modal}
 />
 
@@ -29,16 +36,7 @@ ProgressBars show the progression of a system operation such as downloading, upl
 
 ## Example
 
-<Story
-  name="a) ProgressBars"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
+<Story name="a) ProgressBars">
   <ProgressBar aria-label="Loading…" value={90} />
 </Story>
 
@@ -48,16 +46,7 @@ ProgressBars show the progression of a system operation such as downloading, upl
 
 ProgressBars are controlled with the `value` prop. By default, the `value` prop represents the current percentage of progress, as the minimum (minValue) and maxiumum (maxValue) values default to 0 and 100, respectively.
 
-<Story
-  name="b) Value"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
+<Story name="b) Value">
   <ProgressBar aria-label="Loading…" value={25} />
 </Story>
 
@@ -67,16 +56,7 @@ ProgressBars are controlled with the `value` prop. By default, the `value` prop 
 
 Label can be added to the ProgressBar to provide more context to the user. You can use the `label` prop to provide more context to the user.
 
-<Story
-  name="c) Label"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
+<Story name="c) Label">
   <ProgressBar aria-label="Loading…" label="Loading…" value={90} />
 </Story>
 
@@ -87,16 +67,7 @@ Label can be added to the ProgressBar to provide more context to the user. You c
 By default, ProgressBars are determinate. Use a determinate ProgressBar when progress can be calculated against a specific goal. Use an indeterminate ProgressBar when progress is happening but the time or effort to completion can't be determined.
 In this case set the `isIndeterminate` prop to `true`.
 
-<Story
-  name="d) Indeterminate"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
+<Story name="d) Indeterminate">
   <ProgressBar aria-label="Loading…" isIndeterminate />
 </Story>
 
@@ -118,49 +89,34 @@ For languages that are read right-to-left (e.g. Hebrew and Arabic), the fill of 
 
 ### Size
 
-You can specify the size of the ProgressBar using the `size` prop. The default size is `medium`. The `small` size is recommended for use in tables and the `large` size is recommended for use in modals.
+The container will need to have a width that you want the bar to span else it might seem invisible, if this is the case inspect it to check it has width.
 
-<Story
-  name="e) Size"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
-  <ProgressBar
-    aria-label="Loading…"
-    marginEnd="size-300"
-    size="small"
-    value={30}
-  />
-  <ProgressBar aria-label="Loading…" marginEnd="size-300" value={30} />
-  <ProgressBar aria-label="Loading…" size="large" value={30} />
+You can specify the size of the ProgressBar using the `size` prop. The default size is `medium`.
+
+<Story name="e) Size">
+  <ProgressBar label="Small" aria-label="Loading…" size="small" value={25} />
+  <br />
+  <ProgressBar label="Medium" aria-label="Loading…" value={50} />
+  <br />
+  <ProgressBar label="Large" aria-label="Loading…" size="large" value={75} />
 </Story>
 
 <Source language="tsx" id="status-progressbar--e-size" />
 
 ### Multi-step ProgressBars
 
-ProgressBars can be used to show the progression of a multi-step process. In this case, the `totalSteps` and `currentStep` props should be used to indicate the current step and the total number of steps in the process. The `stepProgress` prop can be used to indicate the progress of the current step.
+ProgressBars can be used to show the progression of a multi-step process, it is possible to provide your own scale via the `maxValue` prop.
 
-<Story
-  name="f) Multi-step ProgressBars"
-  decorators={[
-    (Story) => (
-      <StoryCenteredInline>
-        <Story />
-      </StoryCenteredInline>
-    ),
-  ]}
->
+<Story name="f) Multi-step ProgressBars">
+  <ProgressBar totalSteps={5} value={2.5} maxValue={5} label="Step 2 of 5" />
+  <br />
   <ProgressBar
-    totalSteps={5}
-    currentStep={2}
-    stepProgress={30}
-    label="Step 2 of 5"
+    totalSteps={6}
+    size="large"
+    value={300}
+    maxValue={1800}
+    vol={2}
+    valueLabel="25 mins remaining"
   />
 </Story>
 

--- a/src/stories/UI/ProgressBar.stories.mdx
+++ b/src/stories/UI/ProgressBar.stories.mdx
@@ -128,7 +128,7 @@ Check the table below for a full list of props.
 
 <ArgsTable of={ProgressBar} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/ProgressCircle.stories.mdx
+++ b/src/stories/UI/ProgressCircle.stories.mdx
@@ -164,7 +164,7 @@ Check the table below for a full list of props.
 
 <ArgsTable of={ProgressCircle} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/RadioGroup.stories.mdx
+++ b/src/stories/UI/RadioGroup.stories.mdx
@@ -289,7 +289,7 @@ Example TBC`,
 
 <ArgsTable of={RadioGroup} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Select.stories.mdx
+++ b/src/stories/UI/Select.stories.mdx
@@ -383,7 +383,7 @@ Both a description and an error message can be supplied to a TextField. The desc
 
 <ArgsTable of={SelectType} />
 
-## Stying
+## Styling
 
 Shelley provides a load of visual options via props, if you are building your own theme then you can choose to support the props that you need or just ignore them and drive your variants with classNames instead. The latter might be advised if you are wanting to support a load of themes based off one html output - i.e, you cannot change the props theme to theme but you can swap out the CSS.
 

--- a/src/stories/UI/Switch.stories.mdx
+++ b/src/stories/UI/Switch.stories.mdx
@@ -222,7 +222,7 @@ If you choose to provide your own label you will need to do the latter. _Tip_: C
 
 <ArgsTable of={Switch} />
 
-## Stying
+## Styling
 
 <Source
   language="css"

--- a/src/stories/UI/Text.stories.mdx
+++ b/src/stories/UI/Text.stories.mdx
@@ -245,7 +245,7 @@ Does what it says on the tin really, applies `text-transform` to uppercase. As w
 
 <ArgsTable of={TextPropTable} />
 
-## Stying
+## Styling
 
 Text usually accounts for a large proportion of a website / application and is integral to the overall typographic approach and layout of the design you are implementing. Define it early, tweak as you need.
 

--- a/src/stories/UI/TextField.stories.mdx
+++ b/src/stories/UI/TextField.stories.mdx
@@ -339,7 +339,7 @@ Both a description and an error message can be supplied to a TextField. The desc
 
 argTypes: { label: { control: { type: 'text'} } }
 
-## Stying
+## Styling
 
 Shelley provides a load of visual options via props, if you are building your own theme then you can choose to support the props that you need or just ignore them and drive your variants with classNames instead. The latter might be advised if you are wanting to support a load of themes based off one html output - i.e, you cannot change the props theme to theme but you can swap out the CSS.
 


### PR DESCRIPTION
Tweaks to progress bar:
- Use the `value` prop regardless of multistep + cater for `maxValue` in multistep mode (added some examples).
- Simplified the number of classes by reusing the Step for stepped and non stepped.
- Applied some default styles. 
- Added a `valueLabel` as well in line with Adobe (we already had it defined in our interface).
- Updated tests.