### PR TITLE
feat: Make tweaks to the Menu components allowing for better customisations

### DIFF
--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -42,6 +42,7 @@ function Menu<T extends object>(
           className={classes.item}
           item={item}
           state={state}
+          selectionMode={props.selectionMode}
         />
       ))}
     </ul>

--- a/src/MenuItem/MenuItem.tsx
+++ b/src/MenuItem/MenuItem.tsx
@@ -4,6 +4,7 @@ import { useMenuItem, AriaMenuItemProps } from "react-aria";
 import CheckIcon from "../icons/Check";
 import type { TreeState } from "@react-stately/tree";
 import type { Node } from "@react-types/shared/src/collections";
+import type { SelectionMode } from "@react-types/shared/src/selection";
 import { mergeProps, useFocusRing } from "react-aria";
 import { st, classes } from "./menuItem.st.css";
 
@@ -13,11 +14,18 @@ export interface MenuItemProps<T> extends AriaMenuItemProps {
   item: Node<T>;
   className?: string;
   selectedIcon?: React.ReactNode;
+  selectionMode?: SelectionMode;
 }
 
 export function MenuItem<T extends object>(props: MenuItemProps<T>) {
   const ref = useRef(null);
-  const { className: classNameProp, item, state, selectedIcon } = props;
+  const {
+    className: classNameProp,
+    item,
+    state,
+    selectedIcon,
+    selectionMode,
+  } = props;
   // Get props for the menu item element
   const { isFocusVisible, focusProps } = useFocusRing();
   const { menuItemProps, isFocused, isSelected, isDisabled } = useMenuItem(
@@ -40,6 +48,7 @@ export function MenuItem<T extends object>(props: MenuItemProps<T>) {
           isFocusVisible,
           isSelected,
           isDisabled,
+          selectionMode,
         },
         classNameProp
       )}

--- a/src/MenuItem/menuItem.st.css
+++ b/src/MenuItem/menuItem.st.css
@@ -2,6 +2,7 @@
 
 .root {
   -st-states:
+    selectionMode(enum(none, single, multiple)),
     isDisabled,
     isFocused,
     isSelected,

--- a/src/MenuTrigger/MenuTrigger.tsx
+++ b/src/MenuTrigger/MenuTrigger.tsx
@@ -64,6 +64,8 @@ export interface MenuTriggerProps extends React.HTMLAttributes<HTMLDivElement> {
   crossOffset?: number;
   /** hide the Popup arrow */
   hideArrow?: boolean;
+  /** Override the Popup style via this classname */
+  popupClassName?: string;
 }
 
 export function MenuTrigger({
@@ -79,6 +81,7 @@ export function MenuTrigger({
   portalSelector = "body",
   shouldFlip,
   trigger,
+  popupClassName,
   ...rest
 }: MenuTriggerProps) {
   const triggerRef = React.useRef(null);
@@ -118,6 +121,7 @@ export function MenuTrigger({
           <Popup
             isOpen={state.isOpen}
             onClose={() => state.close()}
+            className={popupClassName}
             {...{
               shouldFlip,
               triggerRef,

--- a/src/icons/AddImage.tsx
+++ b/src/icons/AddImage.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import type { Ref } from "react";
+import { Icon, IconProps } from "../Icon";
+
+const AddImage: React.VFC<IconProps> = (props) => {
+  const { ref, ...rest } = props;
+  return (
+    <Icon {...rest} viewBox="0 0 24 24" ref={ref as Ref<SVGSVGElement>}>
+      <path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"></path>
+    </Icon>
+  );
+};
+export default AddImage;

--- a/src/icons/PermMedia.tsx
+++ b/src/icons/PermMedia.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import type { Ref } from "react";
+import { Icon, IconProps } from "../Icon";
+
+const PermMedia: React.VFC<IconProps> = (props) => {
+  const { ref, ...rest } = props;
+  return (
+    <Icon {...rest} viewBox="0 0 24 24" ref={ref as Ref<SVGSVGElement>}>
+      <path d="M2 6H0v5h.01L0 20c0 1.1.9 2 2 2h18v-2H2V6zm20-2h-8l-2-2H6c-1.1 0-1.99.9-1.99 2L4 16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM7 15l4.5-6 3.5 4.51 2.5-3.01L21 15H7z"></path>
+    </Icon>
+  );
+};
+export default PermMedia;

--- a/src/icons/PictureAsPdf.tsx
+++ b/src/icons/PictureAsPdf.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import type { Ref } from "react";
+import { Icon, IconProps } from "../Icon";
+
+const PictureAsPdf: React.VFC<IconProps> = (props) => {
+  const { ref, ...rest } = props;
+  return (
+    <Icon {...rest} viewBox="0 0 24 24" ref={ref as Ref<SVGSVGElement>}>
+      <path d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8.5 7.5c0 .83-.67 1.5-1.5 1.5H9v2H7.5V7H10c.83 0 1.5.67 1.5 1.5v1zm5 2c0 .83-.67 1.5-1.5 1.5h-2.5V7H15c.83 0 1.5.67 1.5 1.5v3zm4-3H19v1h1.5V11H19v2h-1.5V7h3v1.5zM9 9.5h1v-1H9v1zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm10 5.5h1v-3h-1v3z"></path>
+    </Icon>
+  );
+};
+export default PictureAsPdf;

--- a/src/icons/Share.tsx
+++ b/src/icons/Share.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import type { Ref } from "react";
+import { Icon, IconProps } from "../Icon";
+
+const Share: React.VFC<IconProps> = (props) => {
+  const { ref, ...rest } = props;
+  return (
+    <Icon {...rest} viewBox="0 0 24 24" ref={ref as Ref<SVGSVGElement>}>
+      <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"></path>
+    </Icon>
+  );
+};
+export default Share;

--- a/src/stories/UI/MenuTrigger.examples.tsx
+++ b/src/stories/UI/MenuTrigger.examples.tsx
@@ -8,7 +8,13 @@ import {
   MenuTriggerProps,
   Icon,
 } from "../../indexLib";
+import { default as AddIcon } from "../../icons/Add";
+import { default as AddImageIcon } from "../../icons/AddImage";
+import { default as AddPDFIcon } from "../../icons/PictureAsPdf";
+import { default as AddVideoIcon } from "../../icons/PermMedia";
+import { default as AddSocialIcon } from "../../icons/Share";
 
+import { classes } from "./menuTriggerExample.st.css";
 export const BasicMenuTrigger = (args: MenuTriggerProps) => {
   return (
     <MenuTrigger portalSelector="#portal" {...args}>
@@ -70,15 +76,20 @@ export const MultipleSelectionMenuTrigger = () => {
       // closeOnSelect={false}
       hideArrow
     >
-      <Button tone={10} variant="fab" vol={1}>
-        <Icon alt="Block settings">
-          <g id="ellipsis-dots-h">
-            <path d="M4 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
-            <path d="M10 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
-            <path d="M16 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
-          </g>
-        </Icon>
-      </Button>
+      <Button
+        tone={10}
+        variant="fab"
+        vol={1}
+        icon={
+          <Icon alt="Block settings">
+            <g id="ellipsis-dots-h">
+              <path d="M4 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
+              <path d="M10 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
+              <path d="M16 8c0 1.105-0.895 2-2 2s-2-0.895-2-2c0-1.105 0.895-2 2-2s2 0.895 2 2z"></path>
+            </g>
+          </Icon>
+        }
+      />
       <Menu
         selectionMode="multiple"
         onSelectionChange={(keys) => console.log("selection change", keys)}
@@ -130,5 +141,46 @@ export const MultipleControlled = () => {
       </Menu>
       <p>Current selection (controlled): {[...selected].join(", ")}</p>
     </>
+  );
+};
+
+export const CustomInlineMenu = () => {
+  return (
+    <MenuTrigger
+      portalSelector="#portal"
+      onOpenChange={(isOpen) => console.log("isOpen:", isOpen)}
+      // Automatic if the menus selection type is multiple it will be false but you can override.
+      // closeOnSelect={false}
+      // isOpen
+      hideArrow
+      placement="right"
+      offset={20}
+      popupClassName={classes.inlineMenuPopup}
+    >
+      <Button
+        tone={2}
+        variant="fab"
+        vol={2}
+        icon={<AddIcon alt="Add item" />}
+      />
+      <Menu
+        selectionMode="none"
+        onAction={(value) => console.log(value)}
+        className={classes.inlineMenu}
+      >
+        <Item key="addImage">
+          <AddImageIcon alt="Add image" />
+        </Item>
+        <Item key="addVideo">
+          <AddVideoIcon alt="Add video" />
+        </Item>
+        <Item key="addPDF">
+          <AddPDFIcon alt="Add PDF" />
+        </Item>
+        <Item key="addSocial">
+          <AddSocialIcon alt="Add Social" />
+        </Item>
+      </Menu>
+    </MenuTrigger>
   );
 };

--- a/src/stories/UI/MenuTrigger.examples.tsx
+++ b/src/stories/UI/MenuTrigger.examples.tsx
@@ -173,8 +173,8 @@ export const CustomInlineMenu = () => {
         <Item key="addVideo">
           <AddVideoIcon alt="Add video" />
         </Item>
-        <Item key="addPDF">
-          <AddPDFIcon alt="Add PDF" />
+        <Item key="addDocument">
+          <AddPDFIcon alt="Add Document" />
         </Item>
         <Item key="addSocial">
           <AddSocialIcon alt="Add Social" />

--- a/src/stories/UI/MenuTrigger.examples.tsx
+++ b/src/stories/UI/MenuTrigger.examples.tsx
@@ -14,7 +14,8 @@ import { default as AddPDFIcon } from "../../icons/PictureAsPdf";
 import { default as AddVideoIcon } from "../../icons/PermMedia";
 import { default as AddSocialIcon } from "../../icons/Share";
 
-import { classes } from "./menuTriggerExample.st.css";
+import { classes as triggerExample } from "./menuTriggerExample.st.css";
+
 export const BasicMenuTrigger = (args: MenuTriggerProps) => {
   return (
     <MenuTrigger portalSelector="#portal" {...args}>
@@ -149,13 +150,11 @@ export const CustomInlineMenu = () => {
     <MenuTrigger
       portalSelector="#portal"
       onOpenChange={(isOpen) => console.log("isOpen:", isOpen)}
-      // Automatic if the menus selection type is multiple it will be false but you can override.
-      // closeOnSelect={false}
       // isOpen
       hideArrow
       placement="right"
       offset={20}
-      popupClassName={classes.inlineMenuPopup}
+      popupClassName={triggerExample.inlineMenuPopup}
     >
       <Button
         tone={2}
@@ -166,7 +165,7 @@ export const CustomInlineMenu = () => {
       <Menu
         selectionMode="none"
         onAction={(value) => console.log(value)}
-        className={classes.inlineMenu}
+        className={triggerExample.inlineMenu}
       >
         <Item key="addImage">
           <AddImageIcon alt="Add image" />

--- a/src/stories/UI/MenuTrigger.stories.mdx
+++ b/src/stories/UI/MenuTrigger.stories.mdx
@@ -9,6 +9,7 @@ import {
   IconTriggerMenu,
   ButtonGroupTriggerMenu,
   MultipleSelectionMenuTrigger,
+  CustomInlineMenu,
 } from "./MenuTrigger.examples";
 
 <Meta
@@ -135,6 +136,16 @@ Additional options can be set via `popupProps`:
 <Canvas>
   <Story name="e) Menu button group">
     <ButtonGroupTriggerMenu />
+  </Story>
+</Canvas>
+
+## Custom Inline Menu
+
+We can use CSS to alter the way the menu feels. The following example is inspired by the the Material UI 'Speed Dial' component.
+
+<Canvas>
+  <Story name="f) Custom menu">
+    <CustomInlineMenu />
   </Story>
 </Canvas>
 

--- a/src/stories/UI/Modal.examples.tsx
+++ b/src/stories/UI/Modal.examples.tsx
@@ -18,7 +18,6 @@ import { useState, useRef } from "react";
 import { useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState } from "react-stately";
 
-// import "./modalExample.st.css";
 import { classes as modalClasses } from "./modalExample.st.css";
 
 export const BasicModal = () => {

--- a/src/stories/UI/menuTriggerExample.st.css
+++ b/src/stories/UI/menuTriggerExample.st.css
@@ -1,0 +1,40 @@
+@st-import Menu from "../../Menu/menu.st.css";
+@st-import MenuItem from "../../MenuItem/menuItem.st.css";
+@st-import Popup from "../../Popup/popup.st.css";
+
+.inlineMenu {
+  -st-extends: Menu;
+}
+
+Popup.inlineMenuPopup {
+  border: none;
+  background-color: transparent;
+}
+
+Menu.inlineMenu {
+  display: inline-flex;
+  gap: 1em;
+  border: none
+}
+
+Menu.inlineMenu::item {
+  border-left: none;
+  border-radius: 999px;
+  width: 40px;
+  height: 40px;
+  font-size: 1.55em;
+}
+
+Menu.inlineMenu MenuItem::text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+Menu.inlineMenu MenuItem:isFocused {
+  /* background-color: transparent; */
+}
+
+Menu.inlineMenu svg {
+  grid-area: "checkmark";
+}

--- a/src/stories/UI/menuTriggerExample.st.css
+++ b/src/stories/UI/menuTriggerExample.st.css
@@ -1,40 +1,43 @@
 @st-import Menu from "../../Menu/menu.st.css";
 @st-import MenuItem from "../../MenuItem/menuItem.st.css";
 @st-import Popup from "../../Popup/popup.st.css";
+@st-import Shelley from "../../styles/shelley/project.st.css";
 
 .inlineMenu {
   -st-extends: Menu;
 }
 
-Popup.inlineMenuPopup {
-  border: none;
-  background-color: transparent;
-}
+@st-scope Shelley {
+  Popup.inlineMenuPopup {
+    border: none;
+    background-color: transparent;
+  }
 
-Menu.inlineMenu {
-  display: inline-flex;
-  gap: 1em;
-  border: none
-}
+  Menu.inlineMenu {
+    display: inline-flex;
+    gap: 1em;
+    border: none
+  }
 
-Menu.inlineMenu::item {
-  border-left: none;
-  border-radius: 999px;
-  width: 40px;
-  height: 40px;
-  font-size: 1.55em;
-}
+  Menu.inlineMenu::item {
+    border-left: none;
+    border-radius: 999px;
+    width: 40px;
+    height: 40px;
+    font-size: 1.55em;
+  }
 
-Menu.inlineMenu MenuItem::text {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+  Menu.inlineMenu MenuItem::text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
-Menu.inlineMenu MenuItem:isFocused {
-  /* background-color: whatever-you-like; */
-}
+  Menu.inlineMenu MenuItem:isFocused {
+    /* background-color: whatever-you-like; */
+  }
 
-Menu.inlineMenu svg {
-  grid-area: "checkmark";
+  Menu.inlineMenu svg {
+    grid-area: "checkmark";
+  }
 }

--- a/src/stories/UI/menuTriggerExample.st.css
+++ b/src/stories/UI/menuTriggerExample.st.css
@@ -32,7 +32,7 @@ Menu.inlineMenu MenuItem::text {
 }
 
 Menu.inlineMenu MenuItem:isFocused {
-  /* background-color: transparent; */
+  /* background-color: whatever-you-like; */
 }
 
 Menu.inlineMenu svg {

--- a/src/stories/UI/modalExample.st.css
+++ b/src/stories/UI/modalExample.st.css
@@ -1,11 +1,6 @@
 @st-import Modal, [enter, enterActive, enterDone, exit, exitActive, content, backdrop] from "../../Modal/modal.st.css";
 @st-import Shelley from "../../styles/shelley/project.st.css";
 
-
-
-
-
-
 @st-scope Shelley {
 
   /* Backdrop - Any backdrop styles*/

--- a/src/styles/default/menuItem.st.css
+++ b/src/styles/default/menuItem.st.css
@@ -7,7 +7,7 @@
  * CSS API: https://github.com/action-is-hope/shelley/blob/main/src/MenuItem/menuItem.st.css
  * 
  */
-@st-import Default from "./project.st.css";
+@st-import Default, [--spacing-unit] from "./project.st.css";
 @st-import MenuItem from "../../MenuItem/menuItem.st.css";
 @st-import [
     menuItem,
@@ -20,6 +20,15 @@
 @st-scope Default {
   MenuItem {
     -st-mixin: menuItem;
+  }
+
+  MenuItem:selectionMode(none) {
+    grid-template-columns: calc(var(--spacing-unit) / 2) auto 1fr auto auto calc(var(--spacing-unit) / 2);
+    grid-template-areas:
+      ". . . . . ."
+      ".icon text end keyboard."
+      ".icon description end keyboard."
+      ". . . . . .";
   }
 
   MenuItem:isDisabled {


### PR DESCRIPTION
Allows for more things to be overridable:
- `selectionMode` added as a CSS state to `MenuItem` allowing us to override its layout
- `menuTrigger` allows for its internal `PopUp` to have a custom class

These two changes mean we can make a menu that looks very (see example -> `menuTriggerExample.st.css`) much like the `SpeedDial` component, [see preview](https://deploy-preview-144--friendly-carson-8ec26b.netlify.app/?path=/story/selection-menu-trigger--f-custom-menu) found in Material UI which is also a 'menu'. It's not exactly the same in how it works (i.e on mouse over, requires selection like regular menu) but if you are porting from a project that uses a Speed Dial then this sort of thing is a close fit and you can customise it however you like. We are still missing a tooltip but it's coming.