### PR TITLE
fix: modal blur issue when using focusOn inside a Modal + expose hasValue on text based fields

### DIFF
--- a/src/ComboBox/ComboBox.tsx
+++ b/src/ComboBox/ComboBox.tsx
@@ -68,6 +68,7 @@ function ComboBox<T extends object>(
     description,
     isDisabled,
     isReadOnly,
+    hasValue,
     errorMessage,
     validationState,
     portalSelector = "body",
@@ -213,7 +214,7 @@ function ComboBox<T extends object>(
         variant,
         vol,
         "data-id": dataId,
-        hasValue: Boolean(inputProps.value),
+        hasValue: hasValue ?? Boolean(inputProps.value),
       }}
       className={st(classes.root, classNameProp)}
     >

--- a/src/ComboBoxMultiSelect/ComboBoxMultiSelect.tsx
+++ b/src/ComboBoxMultiSelect/ComboBoxMultiSelect.tsx
@@ -92,6 +92,7 @@ function ComboBoxMultiSelect<
     isDisabled,
     isReadOnly,
     errorMessage,
+    hasValue,
     validationState,
     portalSelector = "body",
     variant,
@@ -391,7 +392,7 @@ function ComboBoxMultiSelect<
         fieldContainerProps: {
           ref: fieldContainerRef,
         },
-        hasValue: Boolean(inputProps.value),
+        hasValue: hasValue ?? Boolean(inputProps.value),
         label,
         labelPosition,
         labelProps: getLabelProps(),

--- a/src/Modal/modal.st.css
+++ b/src/Modal/modal.st.css
@@ -41,7 +41,7 @@
   position: relative;
 }
 
-.blurBackground [data-focus-on-hidden]:not(.root) {
+.blurBackground [data-focus-on-hidden]:not(.root, .root *) {
   opacity: .5;
   filter: blur(2px);
 }

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -76,6 +76,7 @@ function Select<T extends object>(
     shouldFocusOnHover = true,
     triggerIcon = <AngleDown />,
     "data-id": dataId,
+    hasValue,
   } = props;
   // Create state based on the incoming props
   const state = useSelectState(props);
@@ -120,6 +121,7 @@ function Select<T extends object>(
         fieldContainerProps: {
           ref: fieldContainerRef,
         },
+        hasValue,
         disableLabelTransition:
           disableLabelTransition || state.isOpen || Boolean(state.selectedItem),
         variant,

--- a/src/TextField/TextField.tsx
+++ b/src/TextField/TextField.tsx
@@ -51,10 +51,11 @@ function TextField(
     type = "text",
     value,
     defaultValue,
+    hasValue,
     "data-id": dataId,
   } = props;
   /**
-   * textValue stores the value to be used to format multiline and stylews for hasValue:
+   * textValue stores the value to be used to format multiline and styles for hasValue:
    * https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
    */
   // @todo useEffect else it won't work onload with values applied
@@ -85,7 +86,7 @@ function TextField(
         validationState,
         label,
         startAdornment,
-        hasValue: Boolean(textValue),
+        hasValue: hasValue ?? Boolean(textValue),
         isRequired,
         isReadOnly,
         endAdornment,

--- a/src/stories/UI/ComboBox.examples.tsx
+++ b/src/stories/UI/ComboBox.examples.tsx
@@ -22,6 +22,7 @@ export const BasicComboBox = () => {
         label="Favorite Animal"
         portalSelector="#portal"
         shouldFocusWrap
+        placeholder="Placeholder"
       >
         <Item key="red panda">Red Panda</Item>
         <Item key="cat">Cat</Item>

--- a/src/stories/UI/ComboBoxMultiSelect.examples.tsx
+++ b/src/stories/UI/ComboBoxMultiSelect.examples.tsx
@@ -48,6 +48,7 @@ export const BasicComboBox = () => {
         portalSelector="#portal"
         items={books}
         defaultValue={initialSelectedItems}
+        placeholder="Placeholder"
         // value={initialSelectedItems}
         // loadingState={"loading"}
         // inputValue="Lee"

--- a/src/stories/UI/TextField.stories.mdx
+++ b/src/stories/UI/TextField.stories.mdx
@@ -84,7 +84,7 @@ Allows our wonderful users to tell us something interesting by inputting some te
 <Story
   name="a) TextField"
   args={{
-    label: "Name Name Name  Name NameName Name Name Name Name",
+    label: "Name",
   }}
   parameters={{
     docs: {


### PR DESCRIPTION
Stop the blur background from blurring anything inside of a Modal and use hasValue prop on fields to force the label in its focused position when using labelPos over.