### PR TITLE
fix: Firefox Select in overflow: scroll not selectable

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -180,6 +180,8 @@ function Select<T extends object>(
                     localRef?.current && localRef.current.focus();
                   },
                   returnFocus: false,
+                  // Firefox issue where within a scroll container the popup flashes open/closed.
+                  scrollLock: false,
                 },
                 "data-id": dataId ? `${dataId}--popup` : undefined,
               }}


### PR DESCRIPTION
Workaround the Firefox issue where in an overflow scroll container the Popup is not visually maintained to allow a selection.