### PR TITLE
fix: Apply same fix to Menu Trigger that was applied to Select

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "editor.detectIndentation": false,
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "files.insertFinalNewline": true,
   "explorer.sortOrderLexicographicOptions": "upper",

--- a/src/MenuTrigger/MenuTrigger.tsx
+++ b/src/MenuTrigger/MenuTrigger.tsx
@@ -84,7 +84,7 @@ export function MenuTrigger({
   popupClassName,
   ...rest
 }: MenuTriggerProps) {
-  const triggerRef = React.useRef(null);
+  const triggerRef = React.useRef<HTMLElement>(null);
   const [menuTriggerChild, menuChild] = React.Children.toArray(children);
 
   // Create state based on the incoming props /// removed props...
@@ -128,6 +128,15 @@ export function MenuTrigger({
               placement,
               offset,
               crossOffset,
+              focusOnProps: {
+                onDeactivation: () => {
+                  // Manually setting focus back as return focus only works once. @todo Investigate.
+                  triggerRef?.current && triggerRef.current.focus();
+                },
+                returnFocus: false,
+                // Firefox issue where within a scroll container the popup flashes open/closed.
+                scrollLock: false,
+              },
               ...rest,
             }}
             shouldCloseOnBlur


### PR DESCRIPTION
More components likely have this issue when in scrollable containers on FireFox but need time to investigate properly, this unblocks the CMS repo for now.