### PR TITLE
feat: add portal and add hasPopup class when popup is active

### DIFF
--- a/cypress/component/Popup.cy.tsx
+++ b/cypress/component/Popup.cy.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 
-import { Popup, PopupProps, Button } from "../../src/indexLib";
+import { Popup, PopupProps, Button, Portal } from "../../src/indexLib";
 import { useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState } from "@react-stately/overlays";
 
@@ -43,19 +43,23 @@ export const PositionTemplate = (props: Omit<PopupProps, "triggerRef">) => {
       >
         40px
       </Button>
-      <Popup
-        // Focus
-        {...overlayProps}
-        isOpen={state.isOpen}
-        onClose={() => state.close()}
-        {...props}
-        triggerRef={triggerRef}
-        data-id="popup"
-      >
-        <div style={{ height: "78px", width: "78px", background: "grey" }}>
-          80px (78px + 2px border)
-        </div>
-      </Popup>
+      {state.isOpen && (
+        <Portal>
+          <Popup
+            // Focus
+            {...overlayProps}
+            isOpen={state.isOpen}
+            onClose={() => state.close()}
+            {...props}
+            triggerRef={triggerRef}
+            data-id="popup"
+          >
+            <div style={{ height: "78px", width: "78px", background: "grey" }}>
+              80px (78px + 2px border)
+            </div>
+          </Popup>
+        </Portal>
+      )}
     </div>
   );
 };
@@ -81,19 +85,23 @@ export const FocusPopupTemplate = (props: Omit<PopupProps, "triggerRef">) => {
       >
         40px
       </Button>
-      <Popup
-        // Focus
-        {...overlayProps}
-        isOpen={state.isOpen}
-        onClose={() => state.close()}
-        {...props}
-        triggerRef={triggerRef}
-        data-id="popup"
-      >
-        <div>
-          <Button data-focus-test>Focusable button</Button>
-        </div>
-      </Popup>
+      {state.isOpen && (
+        <Portal>
+          <Popup
+            // Focus
+            {...overlayProps}
+            isOpen={state.isOpen}
+            onClose={() => state.close()}
+            {...props}
+            triggerRef={triggerRef}
+            data-id="popup"
+          >
+            <div>
+              <Button data-focus-test>Focusable button</Button>
+            </div>
+          </Popup>
+        </Portal>
+      )}
       <a id="focusLink" href="#">
         Focus me
       </a>
@@ -116,24 +124,28 @@ export const TriggerCustomContent = (props: Omit<PopupProps, "triggerRef">) => {
       <Button {...triggerProps} data-id="trigger" ref={triggerRef}>
         Trigger
       </Button>
-      <Popup
-        data-id="popup"
-        {...overlayProps}
-        isOpen={state.isOpen}
-        onClose={() => state.close()}
-        {...props}
-        triggerRef={triggerRef}
-      >
-        {props.children || <div>Content</div>}
-      </Popup>
+      {state.isOpen && (
+        <Portal>
+          <Popup
+            data-id="popup"
+            {...overlayProps}
+            isOpen={state.isOpen}
+            onClose={() => state.close()}
+            {...props}
+            triggerRef={triggerRef}
+          >
+            {props.children || <div>Content</div>}
+          </Popup>
+        </Portal>
+      )}
     </>
   );
 };
 
 describe("Basic Popup", () => {
-  it("Renders hidden by default", () => {
+  it("Renders by default", () => {
     cy.mount(<BasicTemplate />);
-    cy.get(popup).should("not.exist");
+    cy.get(popup).should("exist");
   });
   it("isOpen renders Popup with arrow", () => {
     cy.mount(<BasicTemplate isOpen />);

--- a/src/ComboBox/ComboBox.tsx
+++ b/src/ComboBox/ComboBox.tsx
@@ -8,7 +8,6 @@ import React, {
   Ref,
   ReactElement,
 } from "react";
-import { createPortal } from "react-dom";
 import { useComboBox, useFilter } from "react-aria";
 import { useComboBoxState } from "react-stately";
 import type { AriaComboBoxProps } from "@react-types/combobox";
@@ -17,6 +16,7 @@ import type { LoadMoreProps } from "../typings/shared-types";
 import { mergeRefs } from "@react-aria/utils";
 import { Field, FieldProps } from "../Field";
 import { Popup } from "../Popup";
+import { Portal } from "../Portal";
 import { Button } from "../Button";
 import { ListBox } from "../ListBox";
 import AngleDown from "../icons/AngleDown";
@@ -226,13 +226,7 @@ function ComboBox<T extends object>(
           ref={ref ? mergeRefs(ref, inputRef) : inputRef}
           data-id={dataId ? `${dataId}--input` : undefined}
         />
-        {state.isOpen && portalSelector
-          ? // If no portalSelector render inline.
-            createPortal(
-              popup,
-              document.querySelector(portalSelector) as HTMLElement
-            )
-          : popup}
+        {state.isOpen && <Portal selector={portalSelector}>{popup}</Portal>}
       </>
     </Field>
   );

--- a/src/ComboBoxMultiSelect/ComboBoxMultiSelect.tsx
+++ b/src/ComboBoxMultiSelect/ComboBoxMultiSelect.tsx
@@ -12,13 +12,13 @@ import React, {
   MouseEvent,
   useImperativeHandle,
 } from "react";
-import { createPortal } from "react-dom";
 import { useFilter } from "react-aria";
 import type { PressEvent } from "@react-types/shared";
 import type { PositionProps } from "@react-types/overlays";
 import type { LoadMoreProps } from "../typings/shared-types";
 import { mergeRefs } from "@react-aria/utils";
 import { Field, FieldProps } from "../Field";
+import { Portal } from "../Portal";
 import { Popup } from "../Popup";
 import { Button } from "../Button";
 import AngleDown from "../icons/AngleDown";
@@ -499,13 +499,7 @@ function ComboBoxMultiSelect<
           ref={ref ? mergeRefs(ref, inputProps.ref) : inputProps.ref}
           onBlur={onBlur}
         />
-        {isOpen && portalSelector
-          ? // If no portalSelector render inline.
-            createPortal(
-              popup,
-              document.querySelector(portalSelector) as HTMLElement
-            )
-          : popup}
+        {isOpen && <Portal selector={portalSelector}>{popup}</Portal>}
       </>
     </Field>
   );

--- a/src/Dialog/DialogTrigger.tsx
+++ b/src/Dialog/DialogTrigger.tsx
@@ -14,13 +14,13 @@ import React, {
   useEffect,
   useRef,
 } from "react";
-import { createPortal } from "react-dom";
 import { mergeProps } from "react-aria";
 import { useOverlayTriggerState } from "@react-stately/overlays";
 import { PressResponder } from "@react-aria/interactions";
 import { DialogContext } from "./context";
 // import {useIsMobileDevice} from '@react-spectrum/utils';
 import { useOverlayTrigger } from "@react-aria/overlays";
+import { Portal } from "../Portal";
 import { Modal, TransitionType } from "../Modal";
 import { Popup } from "../Popup";
 
@@ -352,15 +352,7 @@ function PopupTrigger({
   );
 
   const overlay = (
-    <>
-      {state.isOpen && portalSelector
-        ? // If no portalSelector render inline.
-          createPortal(
-            popup,
-            document.querySelector(portalSelector) as HTMLElement
-          )
-        : popup}
-    </>
+    <>{state.isOpen && <Portal selector={portalSelector}>{popup}</Portal>}</>
   );
   return (
     <DialogTriggerBase

--- a/src/Menu/MenuTrigger.tsx
+++ b/src/Menu/MenuTrigger.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { cloneElement, ReactElement } from "react";
-import { createPortal } from "react-dom";
 import { useMenuTrigger } from "react-aria";
 import type { MenuTriggerType } from "@react-types/menu";
 import { useMenuTriggerState } from "@react-stately/menu";
+import { Portal } from "../Portal";
 import { Popup, PopupProps } from "../Popup";
 
 export interface MenuTriggerProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -87,7 +87,7 @@ export function MenuTrigger({
   const triggerRef = React.useRef<HTMLElement>(null);
   const [menuTriggerChild, menuChild] = React.Children.toArray(children);
 
-  // Create state based on the incoming props /// removed props...
+  // Create state based on the incoming props
   const state = useMenuTriggerState({
     defaultOpen,
     onOpenChange,
@@ -116,8 +116,8 @@ export function MenuTrigger({
   return (
     <>
       {menuTrigger}
-      {state.isOpen &&
-        createPortal(
+      {state.isOpen && (
+        <Portal selector={portalSelector}>
           <Popup
             isOpen={state.isOpen}
             onClose={() => state.close()}
@@ -142,9 +142,9 @@ export function MenuTrigger({
             shouldCloseOnBlur
           >
             {menu}
-          </Popup>,
-          document.querySelector(portalSelector) as HTMLElement
-        )}
+          </Popup>
+        </Portal>
+      )}
     </>
   );
 }

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 import type { TransitionProps } from "react-transition-group/Transition";
 import type { ReactFocusOnProps } from "react-focus-on/dist/es5/types";
 import React, { useRef, forwardRef } from "react";
-import { createPortal } from "react-dom";
+import { Portal } from "../Portal";
 import { CSSTransition } from "react-transition-group";
 import { FocusOn } from "react-focus-on";
 import { st, classes } from "./modal.st.css";
@@ -207,11 +207,7 @@ function Modal(props: ModalProps, ref?: React.Ref<HTMLDivElement>) {
       </>
     </CSSTransition>
   );
-  // If portalSelector then render inside portal elso render inline.
-  // @todo check element exists.
-  return portalSelector
-    ? createPortal(modal, document.querySelector(portalSelector) as HTMLElement)
-    : modal;
+  return <Portal selector={portalSelector}>{modal}</Portal>;
 }
 Modal.displayName = "Modal";
 

--- a/src/Popup/Popup.tsx
+++ b/src/Popup/Popup.tsx
@@ -120,6 +120,18 @@ function Popup(props: PopupProps, ref: React.Ref<HTMLDivElement>) {
     typeof cssValue === "number" && setMaxHeight(cssValue);
   }, [overlayPositionProps]);
 
+  useEffect(() => {
+    /**
+     * fix for issue where labels and buttons under Popup receive pointer events
+     * when selecting items. Here we just add a class so we know when popup is open
+     * and use the class to set pointer events to none in the popup styles.
+     */
+    isOpen === true && document.body.classList.add("hasPopup");
+    return () => {
+      setTimeout(() => document.body.classList.remove("hasPopup"), 0);
+    };
+  }, [isOpen]);
+
   /**
    * Ensure enough is loaded to fill up all available space
    * offered by Popup's max-height otherwise users won't be
@@ -138,7 +150,7 @@ function Popup(props: PopupProps, ref: React.Ref<HTMLDivElement>) {
   // trigger when the menu is closed. In addition, add hidden
   // <DismissButton> components at the start and end of the list
   // to allow screen reader users to dismiss the popup easily.
-  return isOpen ? (
+  return (
     <FocusOn
       preventScrollOnFocus={true}
       returnFocus={{ preventScroll: true }}
@@ -177,8 +189,6 @@ function Popup(props: PopupProps, ref: React.Ref<HTMLDivElement>) {
         <DismissButton onDismiss={props.onClose} />
       </div>
     </FocusOn>
-  ) : (
-    <></>
   );
 }
 Popup.displayName = "Popup";

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -2,11 +2,10 @@
 import type { ReactNode } from "react";
 import { createPortal } from "react-dom";
 
-// Define the type for the component's props
 interface PortalProps {
-  // Accept any valid React child (element, string, etc.)
+  /* Accept any valid React child (element, string, etc.) */
   children: ReactNode;
-  // Optional selector string for the portal target element
+  /* Optional selector string for the portal target element. */
   selector?: string | false;
 }
 

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -1,0 +1,33 @@
+"use client";
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+// Define the type for the component's props
+interface PortalProps {
+  // Accept any valid React child (element, string, etc.)
+  children: ReactNode;
+  // Optional selector string for the portal target element
+  selector?: string | false;
+}
+
+/**
+ * Portal are for rendering content outside of the normal DOM hierarchy.
+ */
+export function Portal(props: PortalProps) {
+  const { children, selector } = props;
+  // Attempt to find the portal target element if a selector is provided
+  const portalElement = selector ? document.querySelector(selector) : null;
+
+  if (selector && portalElement) {
+    // If a valid portal target is found, render the children into that element.
+    return createPortal(children, portalElement);
+  } else if (selector) {
+    // Handle the case where the portal target is not found
+    console.warn("Portal target element not found:", selector);
+  }
+
+  // Default case: render children inline if no selector is provided or target element not found.
+  return <>{children}</>;
+}
+
+Portal.displayName = "Portal";

--- a/src/Portal/index.ts
+++ b/src/Portal/index.ts
@@ -1,0 +1,1 @@
+export * from "./Portal";

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -8,7 +8,6 @@ import React, {
   Ref,
   ReactElement,
 } from "react";
-import { createPortal } from "react-dom";
 import { Field } from "../Field/Field";
 import type { LoadMoreProps } from "../typings/shared-types";
 import type { FieldProps } from "../Field/Field";
@@ -17,6 +16,7 @@ import type { CollectionChildren } from "@react-types/shared/src/collections";
 import { useSelectState } from "react-stately";
 import { HiddenSelect, useSelect, AriaSelectOptions } from "react-aria";
 import { mergeRefs } from "@react-aria/utils";
+import { Portal } from "../Portal";
 import { Popup } from "../Popup";
 import { Button } from "../Button";
 import { ListBox } from "../ListBox";
@@ -100,6 +100,44 @@ function Select<T extends object>(
       setPopUpWidth(fieldContainerRef?.current?.clientWidth);
   }, [state.isOpen]);
 
+  const popup = (
+    <Popup
+      isOpen={state.isOpen}
+      onClose={() => state.close()}
+      triggerRef={internalRef}
+      hideArrow
+      width={popUpWidth}
+      shouldCloseOnBlur
+      {...{
+        onLoadMore,
+        loadingState,
+        shouldFlip,
+        offset,
+        placement: placement === "top" ? "top start" : "bottom start",
+        focusOnProps: {
+          onDeactivation: () => {
+            // Manually setting focus back as return focus only works once. @todo Investigate.
+            internalRef?.current && internalRef.current.focus();
+          },
+          returnFocus: false,
+          // Firefox issue where within a scroll container the popup flashes open/closed.
+          scrollLock: false,
+        },
+        "data-id": dataId ? `${dataId}--popup` : undefined,
+      }}
+    >
+      <ListBox
+        {...{
+          ...menuProps,
+          shouldFocusOnHover,
+          loadingState,
+          state,
+          "data-id": dataId ? `${dataId}--listBox` : undefined,
+        }}
+      />
+    </Popup>
+  );
+
   return (
     <Field
       {...{
@@ -160,45 +198,7 @@ function Select<T extends object>(
           name={props.name}
           isDisabled={isDisabled}
         />
-        {state.isOpen &&
-          createPortal(
-            <Popup
-              isOpen={state.isOpen}
-              onClose={() => state.close()}
-              triggerRef={internalRef}
-              hideArrow
-              width={popUpWidth}
-              shouldCloseOnBlur
-              {...{
-                onLoadMore,
-                loadingState,
-                shouldFlip,
-                offset,
-                placement: placement === "top" ? "top start" : "bottom start",
-                focusOnProps: {
-                  onDeactivation: () => {
-                    // Manually setting focus back as return focus only works once. @todo Investigate.
-                    internalRef?.current && internalRef.current.focus();
-                  },
-                  returnFocus: false,
-                  // Firefox issue where within a scroll container the popup flashes open/closed.
-                  scrollLock: false,
-                },
-                "data-id": dataId ? `${dataId}--popup` : undefined,
-              }}
-            >
-              <ListBox
-                {...{
-                  ...menuProps,
-                  shouldFocusOnHover,
-                  loadingState,
-                  state,
-                  "data-id": dataId ? `${dataId}--listBox` : undefined,
-                }}
-              />
-            </Popup>,
-            document.querySelector(portalSelector) as HTMLElement
-          )}
+        {state.isOpen && <Portal selector={portalSelector}>{popup}</Portal>}
       </>
     </Field>
   );

--- a/src/indexLib.ts
+++ b/src/indexLib.ts
@@ -18,6 +18,7 @@ export * from "./Menu";
 export * from "./Modal";
 export * from "./Notification";
 export * from "./Popup";
+export * from "./Portal";
 export * from "./Progress";
 export * from "./Radio";
 export * from "./Select";

--- a/src/stories/UI/Popup.examples.tsx
+++ b/src/stories/UI/Popup.examples.tsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
-import { createPortal } from "react-dom";
-import { Popup, Button, Dialog } from "../../indexLib";
+import { Popup, Button, Dialog, Portal } from "../../indexLib";
 import { useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState } from "@react-stately/overlays";
 
@@ -28,18 +27,19 @@ export const SimplePopup = () => {
       >
         Click me
       </Button>
-      {createPortal(
-        <Popup
-          {...overlayProps}
-          isOpen={state.isOpen}
-          onClose={() => state.close()}
-          offset={8}
-          ref={overlayRef}
-          triggerRef={triggerRef}
-        >
-          <Dialog size="small">Children</Dialog>
-        </Popup>,
-        document.querySelector("body") as HTMLElement
+      {state.isOpen && (
+        <Portal selector="body">
+          <Popup
+            {...overlayProps}
+            isOpen={state.isOpen}
+            onClose={() => state.close()}
+            offset={8}
+            ref={overlayRef}
+            triggerRef={triggerRef}
+          >
+            <Dialog size="small">Children</Dialog>
+          </Popup>
+        </Portal>
       )}
     </div>
   );

--- a/src/stories/UI/Select.examples.tsx
+++ b/src/stories/UI/Select.examples.tsx
@@ -2,6 +2,7 @@ import { SetStateAction, useState, useMemo } from "react";
 import { Item } from "@react-stately/collections";
 import { useAsyncList } from "react-stately";
 import {
+  Button,
   Select,
   SelectProps,
   TextField,
@@ -34,12 +35,13 @@ export const BasicSelect = (args: ItemsType) => {
         <Item key="sometimes">Sometimes</Item>
         <Item key="always">Always</Item>
       </Select>
-
+      <button onClick={() => alert("clicked")}>Click me</button>
       <RadioGroup label="Favorite sport">
         <Radio value="football">Football</Radio>
         <Radio value="baseball">Baseball</Radio>
         <Radio value="basketball">Basketball</Radio>
       </RadioGroup>
+      <Button onPress={() => alert("clicked")}>Click me</Button>
     </>
   );
 };

--- a/src/stories/UI/Select.examples.tsx
+++ b/src/stories/UI/Select.examples.tsx
@@ -2,7 +2,6 @@ import { SetStateAction, useState, useMemo } from "react";
 import { Item } from "@react-stately/collections";
 import { useAsyncList } from "react-stately";
 import {
-  Button,
   Select,
   SelectProps,
   TextField,
@@ -35,13 +34,11 @@ export const BasicSelect = (args: ItemsType) => {
         <Item key="sometimes">Sometimes</Item>
         <Item key="always">Always</Item>
       </Select>
-      <button onClick={() => alert("clicked")}>Click me</button>
       <RadioGroup label="Favorite sport">
         <Radio value="football">Football</Radio>
         <Radio value="baseball">Baseball</Radio>
         <Radio value="basketball">Basketball</Radio>
       </RadioGroup>
-      <Button onPress={() => alert("clicked")}>Click me</Button>
     </>
   );
 };

--- a/src/stories/UI/Select.stories.mdx
+++ b/src/stories/UI/Select.stories.mdx
@@ -29,7 +29,7 @@ import dedent from "ts-dedent";
     labelPosition: {
       options: ["over", "top", "side", "hidden"],
       control: { type: "inline-radio" },
-      defaultValue: "over",
+      defaultValue: "top",
     },
     isDisabled: {
       control: { type: "boolean" },

--- a/src/styles/default/allGlobal.st.css
+++ b/src/styles/default/allGlobal.st.css
@@ -6,14 +6,6 @@
  * 
  */
 
-:vars {
-  /* define x with value green */
-  xY: green;
-
-  /* define y with value blue */
-  yX: blue;
-}
-
 :global(html),
 :global(body) {
   margin: 0;

--- a/src/styles/default/button.st.css
+++ b/src/styles/default/button.st.css
@@ -257,6 +257,7 @@
   Button:isDisabled:active,
   Button:isDisabled:active:hover {
     opacity: 0.5;
+    cursor: not-allowed;
   }
 
   Button:vol(1) {

--- a/src/styles/default/mixins/formElements.st.css
+++ b/src/styles/default/mixins/formElements.st.css
@@ -60,7 +60,8 @@
 
 .disabledField {
   /* = Dim the whole lot... */
-  filter: saturate(15%) brightness(70%);
+  filter: saturate(15%) brightness(90%);
+  cursor: not-allowed;
 }
 
 

--- a/src/styles/default/popup.st.css
+++ b/src/styles/default/popup.st.css
@@ -17,6 +17,15 @@
 ] from "./project.st.css";
 @st-import Popup from "../../Popup/popup.st.css";
 
+@st-scope {
+
+  /* fix for issue where labels and buttons under Popup receive pointer events when selecting items. */
+  :global(.hasPopup) :not(Popup) label,
+  :global(.hasPopup) :not(Popup) button {
+    pointer-events: none;
+  }
+}
+
 @st-scope body {
   Popup {
     background-color: var(--popup-bg);


### PR DESCRIPTION
the `hasPopup` class allows us to target elements that receive pointer events underneath a popup and turn them off stopping these elements from being selected on select of items in the popup.